### PR TITLE
Update workflows for Node 18

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,27 +7,40 @@ on:
     branches: [ master ]
 
 jobs:
-  test-node-16:
-    name: Node.js v16
+  test-node-18:
+    name: Node.js v18
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install peer dependencies
-        run: npx npm-install-peers
 
       - name: Run test
         run: npm run test:report
 
       - name: Report coverage
         run: npm run test:send
+
+  test-node-16:
+    name: Node.js v16
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test
+        run: npm run test
 
   test-node-14:
     name: Node.js v14


### PR DESCRIPTION
Following saplingjs/sapling#519, se Node 18 LTS for the codecov report test run, and linting run.

Retain Node 12 for now, even though it is EOL. If it ever causes major problems, it can be removed without worries.